### PR TITLE
fix broken test (watch on unreadable dir), tweak code, fix race in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.3
-  - tip
+  - 1.3.3
+  - release
+  - go1.4beta1
 
 install: go get -t -v ./...
 

--- a/tailf_test.go
+++ b/tailf_test.go
@@ -1,4 +1,4 @@
-package tailf
+package tailf_test
 
 import (
 	"fmt"
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aybabtme/tailf"
 )
 
 func TestCanFollowFile(t *testing.T) { withTempFile(t, canFollowFile) }
@@ -22,7 +24,7 @@ func canFollowFile(t *testing.T, filename string, file *os.File) error {
 
 	want := strings.Join(toWrite, "")
 
-	follow, err := Follow(filename, true)
+	follow, err := tailf.Follow(filename, true)
 	if err != nil {
 		return fmt.Errorf("creating follower: %v", err)
 	}
@@ -85,7 +87,7 @@ func canFollowFileFromEnd(t *testing.T, filename string, file *os.File) error {
 
 	want := strings.Join(toWrite, "")
 
-	follow, err := Follow(filename, false)
+	follow, err := tailf.Follow(filename, false)
 	if err != nil {
 		return fmt.Errorf("creating follower: %v", err)
 	}
@@ -110,7 +112,7 @@ func canFollowFileFromEnd(t *testing.T, filename string, file *os.File) error {
 	// this should block forever
 	errc := make(chan error, 1)
 	go func() {
-		n, err := follow.Read(make([]byte, 1))
+		n, err := io.ReadAtLeast(follow, make([]byte, 1), 1)
 		t.Logf("read %d bytes after closing", n)
 		errc <- err
 	}()


### PR DESCRIPTION
- Fix test where a watch is on a folder instead of a filename.
- Fix test where a unique call to `Read` is done, when `ReadAtLeast` should be used (`follower` expects clients to retry reads when it returns `0, nil`).

Few style tweak about error checking.
